### PR TITLE
Fix namespacing

### DIFF
--- a/ErrVal/ErrVal.csproj
+++ b/ErrVal/ErrVal.csproj
@@ -5,7 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <AssemblyName>AllianceSoftware.ErrVal</AssemblyName>
-        <Version>0.3.0</Version>
+        <Version>0.4.0</Version>
         <Title>Error By Value</Title>
         <Authors>raphael.mateusdasneves@alliance-software.io</Authors>
         <Description>Rust style Option&lt;T&gt; and Result&lt;T, TErr&gt; types with all functions one knows and loves from Rust.</Description>

--- a/ErrVal/Option/Option.cs
+++ b/ErrVal/Option/Option.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.Contracts;
+using ErrVal.Result;
 
-namespace ErrVal;
+namespace ErrVal.Option;
 
 [Pure]
 public record Option<T> : IComparable<Option<T>> where T : notnull

--- a/ErrVal/Option/OptionExtensions.cs
+++ b/ErrVal/Option/OptionExtensions.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.Contracts;
+using ErrVal.Result;
 
-namespace ErrVal;
+namespace ErrVal.Option;
 
 public static class OptionExtensions
 {

--- a/ErrVal/Result/Result.cs
+++ b/ErrVal/Result/Result.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.Contracts;
+using ErrVal.Option;
 
-namespace ErrVal;
+namespace ErrVal.Result;
 
 [Pure]
 public record Result<T, TErr> : IComparable<Result<T, TErr>> where T : notnull where TErr : notnull

--- a/ErrVal/Result/ResultExtensions.cs
+++ b/ErrVal/Result/ResultExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace ErrVal;
+﻿using ErrVal.Option;
+
+namespace ErrVal.Result;
 
 public static class ResultExtensions
 {

--- a/Test/OptionUnitTests.cs
+++ b/Test/OptionUnitTests.cs
@@ -1,4 +1,5 @@
-using ErrVal;
+using ErrVal.Option;
+using ErrVal.Result;
 
 namespace Test;
 

--- a/Test/ResultUnitTests.cs
+++ b/Test/ResultUnitTests.cs
@@ -1,4 +1,5 @@
-using ErrVal;
+using ErrVal.Option;
+using ErrVal.Result;
 
 namespace Test;
 

--- a/Test/TestDataProvider.cs
+++ b/Test/TestDataProvider.cs
@@ -1,4 +1,5 @@
-using ErrVal;
+using ErrVal.Option;
+using ErrVal.Result;
 
 namespace Test;
 


### PR DESCRIPTION
Sometimes extension methods like Option::Or collide with Result::Or. In order to prevent this, split the namespaces so Option and Result can be imported independently